### PR TITLE
Removed #include<conio.h>

### DIFF
--- a/APPEND.C
+++ b/APPEND.C
@@ -1,9 +1,7 @@
 #include<stdio.h>
-#include<conio.h>
 void main()
 {
 	int a[10],b[10],i,j,m,n;
-	clrscr();
 	printf("Enter the size of first array: ");
 	scanf("%d",&m);
 	printf("\nEnter %d elements into first array:\n",m);
@@ -19,5 +17,4 @@ void main()
 	printf("\nFirst array after appending second array:\n");
 	for(i=0;i<m+n;i++)
 	printf("\n%d",a[i]);
-	getch();
 }

--- a/BINSEARC.C
+++ b/BINSEARC.C
@@ -1,12 +1,9 @@
 #include<stdio.h>
-#include<conio.h>
-
 int search(int [],int,int);
 
 void main()
 {
 	int a[10],i,n,x,loc;
-	clrscr();
 	printf("Enter the size : ");
 	scanf("%d",&n);
 	printf("\nEnter %d elements into the array in ascending order:\n",n);
@@ -17,7 +14,6 @@ void main()
 	loc=search(a,n,x);
 	if(loc==-1) printf("\n%d is not found.",x);
 	else printf("\n%d is found at position %d in the array.",x,loc);
-	getch();
 }
 
 int search(int a[],int n,int v)

--- a/BSERREC.C
+++ b/BSERREC.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 
 int search(int [],int,int);
 int binsearch(int [],int,int,int);
@@ -7,7 +6,6 @@ int binsearch(int [],int,int,int);
 void main()
 {
 	int a[10],i,n,x,loc;
-	clrscr();
 	printf("Enter the size : ");
 	scanf("%d",&n);
 	printf("\nEnter %d elements into the array in ascending order:\n",n);
@@ -18,7 +16,6 @@ void main()
 	loc=search(a,n,x);
 	if(loc==-1) printf("\n%d is not found.",x);
 	else printf("\n%d is found at position %d in the array.",x,loc+1);
-	getch();
 }
 
 int search(int a[],int n,int v)

--- a/BSTSEARC.C
+++ b/BSTSEARC.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 #include<alloc.h>
 
 typedef struct treeNode* treePointer;
@@ -20,7 +19,6 @@ void main()
 	int choice,n;
 	do
 	{
-		clrscr();
 		printf("\n\tBINARY SEARCH TREE OPERATIONS\n");
 		printf("\n\t\t1. Create");
 		printf("\n\t\t2. Search");
@@ -43,7 +41,6 @@ void main()
 				break;
 			default:continue;
 		}
-		getch();
 	}while(choice!=3);
 }
 

--- a/BUBBSORT.C
+++ b/BUBBSORT.C
@@ -1,12 +1,10 @@
 #include<stdio.h>
-#include<conio.h>
 
 void sort(int*,int);
 
 void main()
 {
 	int a[10],n,i;
-	clrscr();
 	printf("Enter the size : ");
 	scanf("%d",&n);
 	printf("\nEnter %d elements into the array :\n",n);
@@ -19,7 +17,6 @@ void main()
 	printf("\n\nArray after sorting  :");
 	for(i=0;i<n;i++)
 	printf(" %d",a[i]);
-	getch();
 }
 
 void sort(int a[],int n)

--- a/CIRQUEUE.C
+++ b/CIRQUEUE.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 
 #define LENGTH 5
 
@@ -15,7 +14,6 @@ void main()
 	int ch,n;
 	do
 	{
-		clrscr();
 		printf("\n\tQUEUE OPERATIONS\n");
 		printf("\n\t\t1.ADD");
 		printf("\n\t\t2.DELETE");
@@ -38,7 +36,6 @@ void main()
 				break;
 			default:continue;
 		}
-		getch();
 	}while(ch!=4);
 }
 

--- a/DHEADLIS.C
+++ b/DHEADLIS.C
@@ -1,6 +1,5 @@
 #include<stdio.h>
 #include<alloc.h>
-#include<conio.h>
 
 typedef struct listnode* listpointer;
 
@@ -27,7 +26,6 @@ void main()
 	head->next=head->prev=head;
 	do
 	{
-		clrscr();
 		printf("\n\tLINKED LIST OPERATIONS\n");
 		printf("\n\t\t1. CREATE");
 		printf("\n\t\t2. LIST");
@@ -59,7 +57,6 @@ void main()
 			       break;
 			default:continue;
 		}
-		getch();
 	}while(choice!=6);
 }
 

--- a/DOUBLLIS.C
+++ b/DOUBLLIS.C
@@ -1,6 +1,5 @@
 #include<stdio.h>
 #include<alloc.h>
-#include<conio.h>
 
 typedef struct listnode* listpointer;
 
@@ -25,7 +24,6 @@ void main()
 	int n,pos;
 	do
 	{
-		clrscr();
 		printf("\n\tLINKED LIST OPERATIONS\n");
 		printf("\n\t\t1. CREATE");
 		printf("\n\t\t2. LIST");
@@ -57,7 +55,6 @@ void main()
 			       break;
 			default:continue;
 		}
-		getch();
 	}while(choice!=6);
 }
 

--- a/EXCHANGESORT.C
+++ b/EXCHANGESORT.C
@@ -1,9 +1,7 @@
 #include<stdio.h>
-​#​include​<​conio.h​>
 void main(void)
 {
     int array[5], i, j, temp,n;  
- ​   ​clrscr​();
     printf("Enter the number of elements : ");
     scanf("%d",&n);
     printf("Enter %d numbers : ",n);
@@ -28,5 +26,4 @@ void main(void)
     {
         printf(" %d ",array[i]);
     }
-    getch();
 }

--- a/HEADLIST.C
+++ b/HEADLIST.C
@@ -1,6 +1,5 @@
 #include<stdio.h>
 #include<alloc.h>
-#include<conio.h>
 
 typedef struct listnode* listpointer;
 
@@ -63,7 +62,6 @@ void main()
 			       break;
 			default:continue;
 		}
-		getch();
 	}while(choice!=7);
 }
 

--- a/INSSORT.C
+++ b/INSSORT.C
@@ -1,12 +1,10 @@
 #include<stdio.h>
-#include<conio.h>
 
 void sort(int*,int);
 
 void main()
 {
 	int a[10],n,i;
-	clrscr();
 	printf("Enter the size : ");
 	scanf("%d",&n);
 	printf("\nEnter %d elements into the array :\n",n);
@@ -19,7 +17,6 @@ void main()
 	printf("\n\nArray after sorting  :");
 	for(i=0;i<n;i++)
 	printf(" %d",a[i]);
-	getch();
 }
 
 void sort(int a[],int n)

--- a/LINKEDLI.C
+++ b/LINKEDLI.C
@@ -1,6 +1,5 @@
 #include<stdio.h>
 #include<alloc.h>
-#include<conio.h>
 
 typedef struct listnode* listpointer;
 
@@ -25,7 +24,6 @@ void main()
 	int n,pos;
 	do
 	{
-		clrscr();
 		printf("\n\tLINKED LIST OPERATIONS\n");
 		printf("\n\t\t1. CREATE");
 		printf("\n\t\t2. LIST");
@@ -57,7 +55,6 @@ void main()
 			       break;
 			default:continue;
 		}
-		getch();
 	}while(choice!=6);
 }
 

--- a/LINSEARC.C
+++ b/LINSEARC.C
@@ -1,12 +1,10 @@
 #include<stdio.h>
-#include<conio.h>
 
 int search(int [],int,int);
 
 void main()
 {
 	int a[10],i,n,x,loc;
-	clrscr();
 	printf("Enter the size : ");
 	scanf("%d",&n);
 	printf("\nEnter %d elements into the array:\n",n);
@@ -17,7 +15,6 @@ void main()
 	loc=search(a,n,x);
 	if(loc==-1) printf("\n%d is not found.",x);
 	else printf("\n%d is found at position %d in the array.",x,loc);
-	getch();
 }
 
 int search(int a[],int n,int v)

--- a/LISTSORT.C
+++ b/LISTSORT.C
@@ -1,6 +1,5 @@
 #include<stdio.h>
 #include<alloc.h>
-#include<conio.h>
 
 typedef struct listnode* listpointer;
 
@@ -21,7 +20,6 @@ void main()
 	int choice;
 	do
 	{
-		clrscr();
 		printf("\n\tLINKED LIST OPERATIONS\n");
 		printf("\n\t\t1. CREATE");
 		printf("\n\t\t2. LIST");
@@ -39,7 +37,6 @@ void main()
 			       break;
 			default:continue;
 		}
-		getch();
 	}while(choice!=4);
 }
 

--- a/PATTERNMATCHING.C
+++ b/PATTERNMATCHING.C
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <string.h>
-#include<conio.h>
 void main()
 {
     char text[20],pat[20];
@@ -9,7 +8,6 @@ void main()
     gets(text);
     printf("Enter the pattern to find : ");
     gets(pat);
-    clrscr();
 
     a = strlen(pat);
     b = strlen(text);
@@ -30,5 +28,4 @@ void main()
     if (flag==0)
         printf("Not found");
 
-    getch();
 }

--- a/POLYARR1.C
+++ b/POLYARR1.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 
 typedef struct {int coef,exp;} polynomial;
 
@@ -10,7 +9,6 @@ void main()
 {
 	polynomial p1[10],p2[10],p3[20],p4[50],t;
 	int n1,n2,n3,n4,i,j,k;
-	clrscr();
 	printf("Number of terms in first polynomial : ");
 	scanf("%d",&n1);
 	printf("\nEnter %d terms for first polynomial:\n",n1);
@@ -53,7 +51,6 @@ void main()
 	print(p3,n3);
 	printf("\nPolynomial product : ");
 	print(p4,n4);
-	getch();
 }
 
 void read(polynomial p[],int n)

--- a/POLYLIN1.C
+++ b/POLYLIN1.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 #include<alloc.h>
 
 typedef struct node* polynomial;
@@ -14,7 +13,6 @@ void main()
 {
 	polynomial p,t;
 	int i,n;
-	clrscr();
 	printf("Number of terms in the polynomial : ");
 	scanf("%d",&n);
 	printf("\nEnter %d terms for the polynomial:\n",n);
@@ -46,5 +44,4 @@ void main()
 		else if(t->exp==1) printf("%dx",t->coef);
 		else printf("%dx^%d",t->coef,t->exp);
 	}
-	getch();
 }

--- a/POSTFIX.C
+++ b/POSTFIX.C
@@ -1,16 +1,13 @@
 #include<stdio.h>
-#include<conio.h>
 
 int evaluate(char*);
 
 void main()
 {
 	char exp[15];
-	clrscr();
 	printf("Enter an expression in postfix form : ");
 	gets(exp);
 	printf("\nResult = %d",evaluate(exp));
-	getch();
 }
 
 int evaluate(char *str)

--- a/QUEUEARR.C
+++ b/QUEUEARR.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 
 #define LENGTH 5
 
@@ -15,7 +14,6 @@ void main()
 	int ch,n;
 	do
 	{
-		clrscr();
 		printf("\n\tQUEUE OPERATIONS\n");
 		printf("\n\t\t1.ADD");
 		printf("\n\t\t2.DELETE");
@@ -38,7 +36,6 @@ void main()
 				break;
 			default:continue;
 		}
-		getch();
 	}while(ch!=4);
 }
 

--- a/QUEUELIN.C
+++ b/QUEUELIN.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 #include<alloc.h>
 
 typedef struct queuenode* queuepointer;
@@ -21,7 +20,6 @@ void main()
 	int ch,n;
 	do
 	{
-		clrscr();
 		printf("\n\tQUEUE OPERATIONS\n");
 		printf("\n\t\t1.ADD");
 		printf("\n\t\t2.DELETE");
@@ -44,7 +42,6 @@ void main()
 				break;
 			default:continue;
 		}
-		getch();
 	}while(ch!=4);
 }
 

--- a/QUIKSORT.C
+++ b/QUIKSORT.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 
 void sort(int*,int);
 void qsort(int*,int,int);
@@ -7,7 +6,6 @@ void qsort(int*,int,int);
 void main()
 {
 	int a[10],n,i;
-	clrscr();
 	printf("Enter the size : ");
 	scanf("%d",&n);
 	printf("\nEnter %d elements into the array :\n",n);
@@ -20,7 +18,6 @@ void main()
 	printf("\n\nArray after sorting  :");
 	for(i=0;i<n;i++)
 	printf(" %d",a[i]);
-	getch();
 }
 
 void sort(int a[],int n)

--- a/SEARCH2D.C
+++ b/SEARCH2D.C
@@ -1,9 +1,7 @@
 #include<stdio.h>
-#include<conio.h>
 void main()
 {
 	int a[10][10],i,j,m,n,x,count=0;
-	clrscr();
 	printf("\nEnter the Row and column : ");
 	scanf("%d%d",&m,&n);
 	printf("\nEnter %d elements : ",m*n);
@@ -27,5 +25,4 @@ void main()
        if(count==0)
     printf("Item Not found");
 
-  getch();
 }

--- a/SELSORT.C
+++ b/SELSORT.C
@@ -1,12 +1,10 @@
 #include<stdio.h>
-#include<conio.h>
 
 void sort(int*,int);
 
 void main()
 {
 	int a[10],n,i;
-	clrscr();
 	printf("Enter the size : ");
 	scanf("%d",&n);
 	printf("\nEnter %d elements into the array :\n",n);
@@ -19,7 +17,6 @@ void main()
 	printf("\n\nArray after sorting  :");
 	for(i=0;i<n;i++)
 	printf(" %d",a[i]);
-	getch();
 }
 
 void sort(int a[],int n)

--- a/SORTSTR.C
+++ b/SORTSTR.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 #include<string.h>
 
 void sort(char [][15],int);
@@ -8,18 +7,15 @@ void main()
 {
 	char list[10][15];
 	int i,n;
-	clrscr();
 	printf("\nEnter number of strings : ");
 	scanf("%d",&n);
 	printf("\nEnter %d strings:\n",n);
-	flushall();
 	for(i=0;i<n;i++)
 	gets(list[i]);
 	sort(list,n);
 	printf("\nSorted list:\n");
 	for(i=0;i<n;i++)
 	printf("\n%s",list[i]);
-	getch();
 }
 void sort(char str[][15],int n)
 {

--- a/SPARSE.C
+++ b/SPARSE.C
@@ -1,11 +1,9 @@
 #include<stdio.h>
-#include<conio.h>
 
 void main()
 {
 	struct {int r,c,v;} terms[10];
 	int rows,cols,n,i,j,k;
-	clrscr();
 	printf("Enter the order of the sparse matrix : ");
 	scanf("%d%d",&rows,&cols);
 	printf("\nEnter the number of non zero elements : ");
@@ -29,5 +27,4 @@ void main()
 			else printf("   0");
 		printf("\n");
 	}
-	getch();
 }

--- a/SPARSE1.C
+++ b/SPARSE1.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 #include<stdlib.h>
 
 typedef struct {int r,c,v;} term;
@@ -17,7 +16,6 @@ sparse mul(sparse,sparse);
 void main()
 {
 	sparse s1,s2,s3,s4;
-	clrscr();
 	printf("Enter the first sparse matrix:");
 	read(&s1);
 	printf("\nEnter the second sparse matrix:");
@@ -32,7 +30,6 @@ void main()
 	printf("\nMatrix product:");
 	s4=mul(s1,s2);
 	print(s4);
-	getch();
 }
 
 void read(sparse* s)

--- a/STACKARR.C
+++ b/STACKARR.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 
 #define LENGTH 5
 
@@ -15,7 +14,6 @@ void main()
 	int ch,n;
 	do
 	{
-		clrscr();
 		printf("\n\tSTACK OPERATIONS\n");
 		printf("\n\t\t1.PUSH");
 		printf("\n\t\t2.POP");
@@ -38,7 +36,6 @@ void main()
 				break;
 			default:continue;
 		}
-		getch();
 	}while(ch!=4);
 }
 

--- a/STACKLIN.C
+++ b/STACKLIN.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 #include<alloc.h>
 
 typedef struct stacknode* stackpointer;
@@ -21,7 +20,6 @@ void main()
 	int ch,n;
 	do
 	{
-		clrscr();
 		printf("\n\tSTACK OPERATIONS\n");
 		printf("\n\t\t1.PUSH");
 		printf("\n\t\t2.POP");
@@ -44,7 +42,6 @@ void main()
 				break;
 			default:continue;
 		}
-		getch();
 	}while(ch!=4);
 }
 

--- a/TREENREC.C
+++ b/TREENREC.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 #include<alloc.h>
 
 typedef struct treeNode* treePointer;
@@ -33,7 +32,6 @@ void main()
 	int choice;
 	do
 	{
-		clrscr();
 		printf("\n\tBINARY TREE OPERATIONS\n");
 		printf("\n\t\t1. Create");
 		printf("\n\t\t2. Traverse preorder");
@@ -62,7 +60,6 @@ void main()
 				break;
 			default:continue;
 		}
-		getch();
 	}while(choice!=6);
 }
 

--- a/TREEREC.C
+++ b/TREEREC.C
@@ -1,5 +1,4 @@
 #include<stdio.h>
-#include<conio.h>
 #include<alloc.h>
 
 typedef struct treeNode* treePointer;
@@ -22,7 +21,6 @@ void main()
 	int choice;
 	do
 	{
-		clrscr();
 		printf("\n\tBINARY TREE OPERATIONS\n");
 		printf("\n\t\t1. Create");
 		printf("\n\t\t2. Traverse preorder");
@@ -62,7 +60,6 @@ void main()
 				break;
 			default:continue;
 		}
-		getch();
 	}while(choice!=5);
 }
 


### PR DESCRIPTION
clrscr() and getch() are both part of conio.h. It is primarily used in MS-DOS based compilers. They are kinda unnecessary. They gives error in new compilers.